### PR TITLE
Revert "defer permission errors"

### DIFF
--- a/lib/omniauth/strategies/mailchimp.rb
+++ b/lib/omniauth/strategies/mailchimp.rb
@@ -45,14 +45,14 @@ module OmniAuth
           data = user_data
           endpoint = data["api_endpoint"]
           apikey = "#{@access_token.token}-#{data['dc']}"
-          @access_token.get("#{endpoint}/2.0/helper/account-details?apikey=#{apikey}").parsed
-        rescue ::OAuth2::Error => e
-          case e.response.parsed["name"]
-          when "User_InvalidRole"
-            # Defer invalid credential errors
-            {}
+          response = @access_token.get("#{endpoint}/2.0/helper/account-details?apikey=#{apikey}").parsed
+          if response["error"]
+            case response["code"]
+            when 109
+              fail!(:invalid_credentials, response["error"])
+            end
           else
-            raise e
+            response
           end
         end
       end


### PR DESCRIPTION
Reverts Privy/omniauth-mailchimp#1
Updated approach is to handle errors in controller action corresponding to `/auth/failure`.

From the [OmniAuth wiki](https://github.com/omniauth/omniauth/wiki):
>by default, if user authentication fails on the provider side, OmniAuth will catch the response and then redirect the request to the path /auth/failure, passing a corresponding error message in a parameter named message.